### PR TITLE
fix: wrong condition of start_hl()

### DIFF
--- a/lua/hlsearch/init.lua
+++ b/lua/hlsearch/init.lua
@@ -12,7 +12,7 @@ end
 
 local function start_hl()
   local res = fn.getreg('/')
-  if vim.v.hlsearch == 1 and not fn.search([[\%#\zs]] .. res, 'cnW') then
+  if vim.v.hlsearch == 1 and fn.search([[\%#\zs]] .. res, 'cnW') == 0 then
     stop_hl()
   end
 end


### PR DESCRIPTION
`fn.search` return a number. "0" means not found