### PR TITLE
search the cursor-position pattern `%#` as is

### DIFF
--- a/lua/hlsearch/init.lua
+++ b/lua/hlsearch/init.lua
@@ -14,7 +14,7 @@ local function start_hl()
   if vim.v.hlsearch ~= 1 then
       return
   end
-  if res:find([[%#]]) then
+  if res:find([[%#]], 1, true) then
       stop_hl()
       return
   end


### PR DESCRIPTION
This fixes #7.

Lua's [doc](https://www.lua.org/manual/5.1/manual.html#pdf-string.find) says that `string.find(s, pattern, [, int [, plain]])` by default considers `pattern` as "magic". This means that `s:find([[%#]])` is looking for an escaped `#`, which leads to `#` itself, instead of the plain `%#`. Here is an example:

```lua
s = [[#]]
print(s:find([[%#]]))          -- start=1 end=1
print(s:find([[%#]], 1, true)) -- nil

s = [[%#]]
print(s:find([[%#]]))          -- start=2 end=2
print(s:find([[%#]], 1, true)) -- start=1 end=2
```

This PR tells `string.find` to search the `%#` pattern as is.
